### PR TITLE
Fixed missing female strings

### DIFF
--- a/templateLaTex/reportisel.cls
+++ b/templateLaTex/reportisel.cls
@@ -246,9 +246,13 @@
 
 \gdef\@singlemauthorstr{Autor}
 \gdef\@manymauthorstr{Autores}
+\gdef\@singlefauthorstr{Autora}
+\gdef\@manyfauthorstr{Autoras}
 
 \gdef\@singlemadviserstr{Professor}
 \gdef\@manymadviserstr{Professores}
+\gdef\@singlefadviserstr{Professora}
+\gdef\@manyfadviserstr{Professoras}
 
 \gdef\@bachelordissertationstr{Relatório}
 


### PR DESCRIPTION
Some gender-specific strings were missing from the definitions.
e.g. When specified that the teacher was female the string "Professora" would not appear.